### PR TITLE
Fix crash on Android below 8.0

### DIFF
--- a/lib/android/src/main/java/com/scan/ServiceTraceCovid.java
+++ b/lib/android/src/main/java/com/scan/ServiceTraceCovid.java
@@ -45,8 +45,6 @@ import com.scan.database.CacheDatabaseHelper;
 import com.scan.model.ScanConfig;
 import com.scan.preference.AppPreferenceManager;
 
-import org.json.JSONException;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Timer;
@@ -174,14 +172,14 @@ public class ServiceTraceCovid extends Service {
                                 // Create notify schuled
                                 try {
                                     AppUtils.createNotifyRequestPermisson(getApplicationContext());
-                                } catch (JSONException e) {
+                                } catch (Exception e) {
                                     e.printStackTrace();
                                 }
                             } else {
                                 // Permission granted
                                 try {
                                     AppUtils.clearNotifyRequestPermisson(getApplicationContext());
-                                } catch (JSONException e) {
+                                } catch (Exception e) {
                                     e.printStackTrace();
                                 }
                             }
@@ -1066,7 +1064,7 @@ public class ServiceTraceCovid extends Service {
                                     // Create notify bluetooth
                                     try {
                                         AppUtils.createNotifyRequestBluetooth(getApplicationContext());
-                                    } catch (JSONException e) {
+                                    } catch (Exception e) {
                                         e.printStackTrace();
                                     }
                                 }
@@ -1086,7 +1084,7 @@ public class ServiceTraceCovid extends Service {
                                 writeLog("Bluetooth : ON");
                                 try {
                                     AppUtils.clearNotifyRequestBluetooth(getApplicationContext());
-                                } catch (JSONException e) {
+                                } catch (Exception e) {
                                     e.printStackTrace();
                                 }
 
@@ -1245,14 +1243,14 @@ public class ServiceTraceCovid extends Service {
                             // Create notify bluetooth
                             try {
                                 AppUtils.createNotifyRequestLocation(getApplicationContext());
-                            } catch (JSONException e) {
+                            } catch (Exception e) {
                                 e.printStackTrace();
                             }
                         }
                     } else {
                         try {
                             AppUtils.clearNotifyRequestLocation(getApplicationContext());
-                        } catch (JSONException e) {
+                        } catch (Exception e) {
                             e.printStackTrace();
                         }
                     }


### PR DESCRIPTION
Crash được mô tả ở https://github.com/BluezoneGlobal/bluezone-app/issues/33

Nguyên nhân: `notificationManager` chỉ được khởi tạo ở dòng này [AppsUtils.java#L209](https://github.com/thenewvu/react-native-bluetooth-scan/blob/master/lib/android/src/main/java/com/scan/AppUtils.java#L209) khi phiên bản Android >= 8.0, trên các phiên bản thấp hơn, biến không được khởi tạo, gọi methods trên biến sẽ bị `NullException`. Vấn đề là ở các vị trí gọi hàm có sử dụng biến này chỉ xử lý `JSONException`, dẫn tới exceptions không được xử lý và ứng dụng crash.

Cách xử lý: Cách xử lý hợp lý là thực thi việc quản lý notifications cho Android < 8.0, nhưng việc này nên để core devs thực hiện vì họ hiểu rõ phần lõi và yêu cầu hơn mình, khách vãng lai như mình chỉ làm hotfix thôi. Mình sửa lai các vị trí gọi hàm để catch tất cả exceptions, để không crash thôi. Mình code không test vì không có sẵn dev env, mong các bạn thông cảm.

Qua lỗi vặt gây hậu quả không vặt này, mình góp ý các bạn devs không nên tin vào IDE, mình đoán các bạn thấy IDE tự viết try-catch nên các bạn nghĩ IDE đủ thông minh để xử lý hết lỗi, hậu quả là như này đây. Góp ý chân thành, không có ý chê bai gì cả, các bạn đang làm việc có ích cho xã hội, cảm ơn các bạn nhiều.

---

Các bạn cũng nên xem xét việc sử dụng [NotificationManagerCompat](https://developer.android.com/reference/androidx/core/app/NotificationManagerCompat#createNotificationChannel(android.app.NotificationChannel)) và các thư viên compat khác để tránh việc rải `if (arch >= xxx)` dẫn tới rất khó để kiểm soát code flow.

@ntcuong ping